### PR TITLE
Update naming convention for documentation

### DIFF
--- a/launchpad-services/launcher-documentation.yaml
+++ b/launchpad-services/launcher-documentation.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: dd46582683577a509a8be339dd59f5b754ff2171
+- hash: None
   name: launcher-documentation
   parameters:
     IMAGE: registry.devshift.net/fabric8/launcher-documentation

--- a/launchpad-services/launcher-documentation.yaml
+++ b/launchpad-services/launcher-documentation.yaml
@@ -2,7 +2,7 @@ services:
 - hash: dd46582683577a509a8be339dd59f5b754ff2171
   name: launcher-documentation
   parameters:
-    IMAGE: registry.devshift.net/openshiftio/launcher-documentation
+    IMAGE: registry.devshift.net/fabric8/launcher-documentation
   path: /openshift/template.yaml
   url: https://github.com/fabric8-launcher/launcher-documentation
   hash_length: 7

--- a/launchpad-services/launcher-documentation.yaml
+++ b/launchpad-services/launcher-documentation.yaml
@@ -1,8 +1,8 @@
 services:
 - hash: dd46582683577a509a8be339dd59f5b754ff2171
-  name: appdev-documentation
+  name: launcher-documentation
   parameters:
-    IMAGE: registry.devshift.net/openshiftio/appdev-documentation
+    IMAGE: registry.devshift.net/openshiftio/launcher-documentation
   path: /openshift/template.yaml
   url: https://github.com/fabric8-launcher/launcher-documentation
   hash_length: 7


### PR DESCRIPTION
Was: appdev-documentation
Change to: launcher-documentation