### PR TITLE
RHEL based launcher-documentation in staging

### DIFF
--- a/launchpad-services/launcher-documentation.yaml
+++ b/launchpad-services/launcher-documentation.yaml
@@ -1,8 +1,13 @@
 services:
 - hash: cbdf416767a7a0e8a5bfc7d4e533bd9641d4ee7f
   name: launcher-documentation
-  parameters:
-    IMAGE: registry.devshift.net/fabric8/launcher-documentation
+  environments:
+  - name: production
+    parameters:
+      IMAGE: registry.devshift.net/fabric8/launcher-documentation
+  - name: staging
+    parameters:
+      IMAGE: prod.registry.devshift.net/osio-prod/fabric8/launcher-documentation
   path: /openshift/template.yaml
   url: https://github.com/fabric8-launcher/launcher-documentation
   hash_length: 7


### PR DESCRIPTION
As part of an effort to migrate the services running in OSIO from CentOS
to RHEL, we are ready to push out the RHEL based image for this service
to staging.

The build for RHEL is enabled in cico:
https://github.com/openshiftio/openshiftio-cico-jobs/blob/d9afbdbdc5bd0bfcfcd763530300671aeffedef3/devtools-ci-index.yaml#L2402

And in the feature repo itself:
https://github.com/fabric8-launcher/launcher-documentation/pull/1104

In this commit we are keeping the prod environment on CentOS but shifting
the staging environment to RHEL in order to validate.