### PR TITLE
Moving replicas back to 1

### DIFF
--- a/launchpad-services/backend.yaml
+++ b/launchpad-services/backend.yaml
@@ -8,14 +8,14 @@ services:
       CPU_LIMIT: 1
       MEMORY_REQUEST: 768M
       MEMORY_LIMIT: 2G
-      REPLICAS: 3
+      REPLICAS: 1
   - name: staging
     parameters:
       CPU_REQUEST: 0.25
       CPU_LIMIT: 1
       MEMORY_REQUEST: 768M
       MEMORY_LIMIT: 2G
-      REPLICAS: 3
+      REPLICAS: 1
   parameters:
     IMAGE: registry.devshift.net/fabric8/launcher-backend
   path: /openshift/template.yaml


### PR DESCRIPTION
Because the route annotation didn't work as expected.

See https://github.com/openshiftio/openshift.io/issues/3410